### PR TITLE
refactor: cache Intl.NumberFormat instances

### DIFF
--- a/constants.tsx
+++ b/constants.tsx
@@ -1,6 +1,7 @@
 import { Person } from "./types";
 import { BudgetPeriodsUtils } from "./lib/utils/budget-periods.utils";
 import { DateUtils } from "./lib/utils/date.utils";
+export { formatCurrency } from "./lib/utils/currency.utils";
 
 // Avatar predefiniti per il mondo della finanza
 export const FINANCE_AVATARS = [
@@ -75,57 +76,6 @@ export const getPersonAvatarIcon = (person: Person) => {
 // Helper per verificare se un avatar è predefinito
 export const isPredefinedAvatar = (avatar: string) => {
   return FINANCE_AVATARS.some((a) => a.id === avatar);
-};
-
-export const formatCurrency = (
-  amount: number,
-  options: {
-    showSign?: boolean;
-    compact?: boolean;
-  } = {}
-) => {
-  try {
-    // Handle compact notation for large numbers
-    if (options.compact && Math.abs(amount) >= 1000) {
-      const absAmount = Math.abs(amount);
-      let value: number;
-      let suffix: string;
-
-      if (absAmount >= 1000000) {
-        value = absAmount / 1000000;
-        suffix = "M";
-      } else {
-        value = absAmount / 1000;
-        suffix = "K";
-      }
-
-      const formatted = new Intl.NumberFormat("it-IT", {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 1,
-      }).format(value);
-
-      const sign = amount < 0 ? "-" : options.showSign && amount > 0 ? "+" : "";
-      return `${sign}€${formatted}${suffix}`;
-    }
-
-    // Standard formatting
-    const formatter = new Intl.NumberFormat("it-IT", {
-      style: "currency",
-      currency: "EUR",
-    });
-
-    const formatted = formatter.format(Math.abs(amount));
-
-    if (options.showSign) {
-      const sign = amount >= 0 ? "+" : "-";
-      return `${sign}${formatted}`;
-    }
-
-    return amount < 0 ? `-${formatted}` : formatted;
-  } catch (error) {
-    console.error("Currency formatting error:", error);
-    return `€${amount.toFixed(2)}`;
-  }
 };
 
 export const formatDate = (dateString: string) => {

--- a/lib/utils/currency.utils.ts
+++ b/lib/utils/currency.utils.ts
@@ -1,0 +1,80 @@
+const DEFAULT_LOCALE = "it-IT";
+const DEFAULT_CURRENCY = "EUR";
+
+// Module-level formatter for standard currency formatting
+const standardFormatter = new Intl.NumberFormat(DEFAULT_LOCALE, {
+  style: "currency",
+  currency: DEFAULT_CURRENCY,
+});
+
+// Cache for any additional formatters (e.g., different locales or options)
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+const getCachedFormatter = (
+  locale: string,
+  options: Intl.NumberFormatOptions
+): Intl.NumberFormat => {
+  const cacheKey = `${locale}-${JSON.stringify(options)}`;
+  let formatter = formatterCache.get(cacheKey);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    formatterCache.set(cacheKey, formatter);
+  }
+  return formatter;
+};
+
+export const formatCurrency = (
+  amount: number,
+  options: {
+    showSign?: boolean;
+    compact?: boolean;
+    locale?: string;
+    currency?: string;
+  } = {}
+) => {
+  const {
+    showSign = false,
+    compact = false,
+    locale = DEFAULT_LOCALE,
+    currency = DEFAULT_CURRENCY,
+  } = options;
+
+  try {
+    if (compact && Math.abs(amount) >= 1000) {
+      const absAmount = Math.abs(amount);
+      const divider = absAmount >= 1_000_000 ? 1_000_000 : 1_000;
+      const suffix = absAmount >= 1_000_000 ? "M" : "K";
+      const value = absAmount / divider;
+
+      const compactFormatter = getCachedFormatter(locale, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 1,
+      });
+
+      const formatted = compactFormatter.format(value);
+      const sign = amount < 0 ? "-" : showSign && amount > 0 ? "+" : "";
+      return `${sign}€${formatted}${suffix}`;
+    }
+
+    const formatter =
+      locale === DEFAULT_LOCALE && currency === DEFAULT_CURRENCY
+        ? standardFormatter
+        : getCachedFormatter(locale, {
+            style: "currency",
+            currency,
+          });
+
+    const formatted = formatter.format(Math.abs(amount));
+
+    if (showSign) {
+      const sign = amount >= 0 ? "+" : "-";
+      return `${sign}${formatted}`;
+    }
+
+    return amount < 0 ? `-${formatted}` : formatted;
+  } catch (error) {
+    console.error("Currency formatting error:", error);
+    return `€${amount.toFixed(2)}`;
+  }
+};
+

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -20,3 +20,6 @@ export { BudgetPeriodsUtils } from './budget-periods.utils';
 export { BudgetUtils } from './budget.utils';
 export type { BudgetCalculationData } from './budget.utils';
 
+// Currency utilities
+export * from './currency.utils';
+


### PR DESCRIPTION
## Summary
- introduce `currency.utils` with module-level Intl.NumberFormat and cached formatter retrieval
- reuse cached formatters in `formatCurrency` and re-export utility from constants

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a61bfee2a4832994c9bb6260802f92